### PR TITLE
Advise to use HTTPS, change curl examples to reflect this

### DIFF
--- a/docs/compendium.md
+++ b/docs/compendium.md
@@ -4,7 +4,7 @@
 
 Will return up to 100 results by default. For pagination purposes, URLs for previous and next results are provided if applicable.
 
-`curl http://…/api/v1/compendium?limit=100&start=2`
+`curl https://…/api/v1/compendium?limit=100&start=2`
 
 `GET /api/v1/compendium?limit=100&start=2`
 
@@ -22,15 +22,16 @@ Will return up to 100 results by default. For pagination purposes, URLs for prev
   "previous":"/api/v1/compendium?limit=100&start=1"
 }
 ```
-__Implemented:__ Yes
 
-__Stability:__ 0 - subject to changes
+**Implemented:** Yes
+
+**Stability:** 0 - subject to changes
 
 ### URL Parameters
 
-* `job_id` - Comma-separated list of related job ids to filter by.
-*  `start` - List from specific search result onwards. 1-indexed. Defaults to 1.
-*  `limit` - Specify maximum amount of results per page. Defaults to 100.
+- `job_id` - Comma-separated list of related job ids to filter by.
+- `start` - List from specific search result onwards. 1-indexed. Defaults to 1.
+- `limit` - Specify maximum amount of results per page. Defaults to 100.
 
 ### Error Responses
 
@@ -44,7 +45,7 @@ __Stability:__ 0 - subject to changes
 
 This includes the complete metadata set, related job ids and a tree representation of the included [files](files.md). The `created` timestamp refers to the upload of the compendium. It is formated as ISO8601.
 
-`curl http://…/api/v1/$ID`
+`curl https://…/api/v1/$ID`
 
 `GET /api/v1/compendium/:id`
 
@@ -57,17 +58,15 @@ This includes the complete metadata set, related job ids and a tree representati
   "created": 2016-08-01T13:57:40.760Z",
   "files": …
  }
-
 ```
 
-__Implemented:__ Yes
+**Implemented:** Yes
 
-__Stability:__ 0 - subject to changes
+**Stability:** 0 - subject to changes
 
 ### URL Parameters
 
-* `:id` - the compendiums id
-
+- `:id` - the compendiums id
 
 ### Error Responses
 
@@ -79,8 +78,7 @@ __Stability:__ 0 - subject to changes
 
 ## List related execution jobs
 
-
-`curl http://…/api/v1/compendium/$ID/jobs`
+`curl https://…/api/v1/compendium/$ID/jobs`
 
 `GET /api/v1/compendium/:id/jobs`
 
@@ -98,12 +96,13 @@ __Stability:__ 0 - subject to changes
 }
 ```
 
-__Implemented:__ Yes
+**Implemented:** Yes
 
-__Stability:__ 0 - subject to changes
+**Stability:** 0 - subject to changes
 
 ### URL Parameters
-* `:id` - compendium id that the results should be related to
+
+- `:id` - compendium id that the results should be related to
 
 ### Error Response
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,9 @@
 ![Opening Reproducible Research](logo.png)
 
-__Current version of the API: v1__
+**Current version of the API: v1**
 
 The o2r web API acts as the interface between the [o2r](https://o2r.info) backend services and the [webinterface](https://github.com/o2r-project/o2r-platform). It includes functionality to [upload](upload.md) and examine [executable research compendia](compendium.md) and run and examine [execution jobs](job.md).
 
-It is implemented as a RESTful API. The entrypoint for the current version is `/api/v1`.
-Unless specified otherwise, responses will always be in JSON format, body parameters are expected in `multipart/form-data` format.
+It is implemented as a RESTful API. The entrypoint for the current version is `/api/v1`. Unless specified otherwise, responses will always be in JSON format, body parameters are expected in `multipart/form-data` format. Requests to the API should always be made with a secure connection, i.e. HTTPS.
 
 We also provide a [simple Postman collection](https://raw.githubusercontent.com/o2r-project/o2r-web-api/master/muncher.postman_collection.json)([getpostman.com](https://www.getpostman.com/)), so that you can comfortably explore the API.

--- a/docs/job.md
+++ b/docs/job.md
@@ -1,22 +1,16 @@
 # Job
-Execution jobs are used to execute a research compendium. When a new execution
-job is started, the contents of the research compendium are cloned to create a
-trackable execution. The status information, logs and final working directory
-data are saved in their final state, so that they can be reviewed later on.
 
-All execution jobs are tied to a single research compendium and reflect the
-execution history of that research compendium.
+Execution jobs are used to execute a research compendium. When a new execution job is started, the contents of the research compendium are cloned to create a trackable execution. The status information, logs and final working directory data are saved in their final state, so that they can be reviewed later on.
 
-A trivial execution job would be a completely unmodified research compendium, to
-test the reproducibility of a research compendium. A _potential_ future feature
-would be that the input data (input files, datasets, parameters) can be altered
-to run a modified execution job. This functionality is not yet final.
+All execution jobs are tied to a single research compendium and reflect the execution history of that research compendium.
+
+A trivial execution job would be a completely unmodified research compendium, to test the reproducibility of a research compendium. A _potential_ future feature would be that the input data (input files, datasets, parameters) can be altered to run a modified execution job. This functionality is not yet final.
 
 ## New Job
 
 Create and run a new execution job. Requires a `compendium_id`.
 
-`curl -F compendium_id=$ID http://…/api/v1/job`
+`curl -F compendium_id=$ID https://…/api/v1/job`
 
 `POST /api/v1/job`
 
@@ -25,34 +19,33 @@ Create and run a new execution job. Requires a `compendium_id`.
 
 {"job_id":"ngK4m"}
 ```
-__Implemented:__ Yes
 
-__Stability:__ 0 - subject to changes
+**Implemented:** Yes
+
+**Stability:** 0 - subject to changes
 
 ### Body parameters:
 
-* `compendium_id` - The `id` of the compendium to base this job on.
-* `steps` - __TODO__ select steps that will be executed (skip some steps in successive executions?)
-* `inputs` - **_proposal_** - Array with one or more `FileDescriptor`.
+- `compendium_id` - The `id` of the compendium to base this job on.
+- `steps` - **TODO** select steps that will be executed (skip some steps in successive executions?)
+- `inputs` - **_proposal_** - Array with one or more `FileDescriptor`.
 
 ### `FileDescriptor`
 
-_The FileDescriptor functionality is only a potential feature and not at all
-finalized._
+_The FileDescriptor functionality is only a potential feature and not at all finalized._
 
-`[FileDescriptor]` allows overriding files from the compendium with files
-from a different execution job or a different compendium.
+`[FileDescriptor]` allows overriding files from the compendium with files from a different execution job or a different compendium.
 
-__`[FileDescriptor]` Syntax:__
+**`[FileDescriptor]` Syntax:**
+
 ```
 ERC/JOB:ID:Source:Destination
 ```
 
-e.g. `ERC:lnj82:/data/bigdataset.Rdata:/data/newinput.Rdata` would provide
-`/data/bigdataset.Rdata` from the `ERC` with the ID `lnj82` as the file
-`/data/newinput.Rdata` in this execution Job.
+e.g. `ERC:lnj82:/data/bigdataset.Rdata:/data/newinput.Rdata` would provide `/data/bigdataset.Rdata` from the `ERC` with the ID `lnj82` as the file `/data/newinput.Rdata` in this execution Job.
 
 ### Error Responses
+
 ```json
 404 Not Found
 
@@ -78,7 +71,7 @@ e.g. `ERC:lnj82:/data/bigdataset.Rdata:/data/newinput.Rdata` would provide
 
 Lists jobs. Will return up to 100 results by default. For pagination purposes, URLs for previous and next results are provided if applicable. Results can be filtered by one or more related `compendium_id`.
 
-`curl -F compendium_id=$ID http://…/api/v1/job?limit=100&start=2&compendium_id=$ID`
+`curl -F compendium_id=$ID https://…/api/v1/job?limit=100&start=2&compendium_id=$ID`
 
 `GET /api/v1/job?limit=100&start=2&compendium_id=a4Dnm`
 
@@ -97,21 +90,21 @@ Lists jobs. Will return up to 100 results by default. For pagination purposes, U
 }
 ```
 
-__Implemented:__ Yes
+**Implemented:** Yes
 
-__Stability:__ 0 - subject to changes
+**Stability:** 0 - subject to changes
 
 ### GET parameters
 
-* `compendium_id` - Comma-separated list of related compendium ids to filter by.
-*  `start` - List from specific search result onwards. 1-indexed. Defaults to 1.
-*  `limit` - Specify maximum amount of results per page. Defaults to 100.
+- `compendium_id` - Comma-separated list of related compendium ids to filter by.
+- `start` - List from specific search result onwards. 1-indexed. Defaults to 1.
+- `limit` - Specify maximum amount of results per page. Defaults to 100.
 
 ## View single Job
 
 View details for a single job. Filelisting format is described in [Files](files.md)
 
-`curl http://…/api/v1/job/$ID`
+`curl https://…/api/v1/job/$ID`
 
 `GET /api/v1/job/:id`
 
@@ -136,34 +129,33 @@ View details for a single job. Filelisting format is described in [Files](files.
 }
 ```
 
-__Implemented:__ Yes
+**Implemented:** Yes
 
-__Stability:__ 0 - subject to changes
-
+**Stability:** 0 - subject to changes
 
 ### URL Parameters
 
-* `:id` - id of the job to be viewed
+- `:id` - id of the job to be viewed
 
 ### Steps
 
 The answer will contain information to the following `steps`:
 
-* `validate_bag`
-* `validate_compendium`
-* `validate_dockerfile`
-* `image_build`
-* `image_execute`
-* `cleanup`
+- `validate_bag`
+- `validate_compendium`
+- `validate_dockerfile`
+- `image_build`
+- `image_execute`
+- `cleanup`
 
 Their status will be one of:
 
-* `queued`
-* `running`
-* `success`
-* `failure`
-* `warning`
-* `skip`
+- `queued`
+- `running`
+- `success`
+- `failure`
+- `warning`
+- `skip`
 
 Additional explanations to their state will be transmitted in the `text` property. The `start` and `end` timestamps indicate the start and end time of the step. They are formatted as ISO8601.
 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,4 +1,4 @@
-#Upload
+# Upload
 
 ## Compendium
 
@@ -8,7 +8,7 @@ Upload a unvalidated research compendium as a compressed archive, either `.zip` 
 curl -F "compendium=@compendium.zip;type=application/zip" \
      -F content_type=compendium_v1 \ 
      -H "X-API-Key: CHANGE_ME" \
-     http://…/api/v1/compendium 
+     https://…/api/v1/compendium
 ```
 
 ```
@@ -22,20 +22,22 @@ X-API-Key: api_key
 
 {"id":"a4Ndl"}
 ```
-__Additional Headers:__
 
-* `X-API-Key` - valid API key for POSTing to /compendium
+**Additional Headers:**
 
-__Body parameters:__
+- `X-API-Key` - valid API key for POSTing to /compendium
 
-* `compendium` - The archive file
-* `content_type` - Form of archive. One of the following:
-    * `compendium_v1` - _default_ - compendium in Bagtainer format
-    * `workspace` - formless workspace
+**Body parameters:**
 
-__Implemented:__ Partially (`content_type` must be `compendium_v1`)
+- `compendium` - The archive file
+- `content_type` - Form of archive. One of the following:
 
-__Stability:__ 0 - subject to changes
+  - `compendium_v1` - _default_ - compendium in Bagtainer format
+  - `workspace` - formless workspace
+
+**Implemented:** Partially (`content_type` must be `compendium_v1`)
+
+**Stability:** 0 - subject to changes
 
 ### Error Responses
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -30,9 +30,9 @@ As the cookie is present in both authenticated and unauthenticated sessions, cli
 
 **Stability:** 2 - will not likely change.
 
-`curl https://`
+`curl https://…/api/v1/auth/whoami --cookie "connect.sid=…`
 
-`GET /api/v1/auth/whoami --cookie "connect.sid=…"`
+`GET /api/v1/auth/whoami`
 
 ```json
 200 OK


### PR DESCRIPTION
Requests to the API should always be made with a secure connection. Otherwise the cookies referencing a (potentially) authenticated session could be leaked, thus leading to possible impersonations.

I've added a recommendation to the front page and changed all `curl` examples to reflect this recommendation.

Also, a few Markdown linting changes are pulled in with this branch.