### PR TITLE
add documentation for sciebo public shares

### DIFF
--- a/docs/public-share.md
+++ b/docs/public-share.md
@@ -11,7 +11,7 @@ The upload is only allowed for logged in users. To run the upload from the comma
 Upon successful download from the public share, the `id` for the new compendium is returned.
 
 ```bash
-curl -F share_url=https://uni-muenster.sciebo.de/index.php/s/c7htJIHGvgWnE6U \
+curl -F share_url=https://uni-muenster.sciebo.de/index.php/s/7EoWgjLSFVV89AO \
 	-F content_type=compendium_v1 http://…/api/v1/public-share \
 	--cookie "connect.sid=<code string here>" \
      http://…/api/v1/public-share
@@ -35,17 +35,19 @@ curl -F share_url=https://uni-muenster.sciebo.de/index.php/s/c7htJIHGvgWnE6U \
 ```json
 401 Unauthorized
 
-{"error":"missing or wrong api key"}
+{"error":"unauthorized: user level does not allow compendium creation"}
 ```
 
 ```json
 403 Forbidden
 
-{"error":"invalid file host"}
+{"error":"public share host is not allowed"}
 ```
 
 ## Example data
 
-For testing you can create a sciebo public share containing one of the example compendia found in the [o2r-bagtainers](https://github.com/o2r-project/o2r-bagtainers) project.
+For testing purposes you can use this sciebo public share: https://uni-muenster.sciebo.de/index.php/s/7EoWgjLSFVV89AO
+ 
+It contains a few ready-to-use compendia found in the [o2r-bagtainers](https://github.com/o2r-project/o2r-bagtainers) project
 
 For more configuration details, see the project's README file.

--- a/docs/public-share.md
+++ b/docs/public-share.md
@@ -1,0 +1,51 @@
+# Public share
+
+## Compendium
+
+__Stability:__ 0 - subject to changes
+
+Upload an unvalidated research compendium by submitting a link to a cloud resource. Currently, only sciebo (https://www.sciebo.de/en/) is supported.
+
+The upload is only allowed for logged in users. To run the upload from the command line, login on the website and open you browser cookies. Find a cookie issued by `o2r.uni-muenster.de` with the name `connect.sid`. Copy the contents of the cookie into the request example below.
+
+Upon successful download from the public share, the `id` for the new compendium is returned.
+
+```bash
+curl -F share_url=https://uni-muenster.sciebo.de/index.php/s/c7htJIHGvgWnE6U \
+	-F content_type=compendium_v1 http://…/api/v1/public-share \
+	--cookie "connect.sid=<code string here>" \
+     http://…/api/v1/public-share
+```
+
+```json
+200 OK
+
+{"id":"b9Faz"}
+```
+
+### Body parameters
+
+- `share_url` - The sciebo link to the public share
+- `content_type` - Form of archive. One of the following:
+  - `compendium_v1` - _default_ - compendium in Bagtainer format
+  - `workspace` - _[NOT IMPLEMENTED]_ - formless workspace
+
+### Error responses
+
+```json
+401 Unauthorized
+
+{"error":"missing or wrong api key"}
+```
+
+```json
+403 Forbidden
+
+{"error":"invalid file host"}
+```
+
+## Example data
+
+For testing you can create a sciebo public share containing one of the example compendia found in the [o2r-bagtainers](https://github.com/o2r-project/o2r-bagtainers) project.
+
+For more configuration details, see the project's README file.

--- a/docs/public-share.md
+++ b/docs/public-share.md
@@ -46,8 +46,9 @@ curl -F share_url=https://uni-muenster.sciebo.de/index.php/s/7EoWgjLSFVV89AO \
 
 ## Example data
 
-For testing purposes you can use this sciebo public share: https://uni-muenster.sciebo.de/index.php/s/7EoWgjLSFVV89AO
+For testing purposes you can the following sciebo public share. It contains a few ready-to-use compendia found in the [o2r-bagtainers](https://github.com/o2r-project/o2r-bagtainers) project:
+
+`https://uni-muenster.sciebo.de/index.php/s/7EoWgjLSFVV89AO`
  
-It contains a few ready-to-use compendia found in the [o2r-bagtainers](https://github.com/o2r-project/o2r-bagtainers) project
 
 For more configuration details, see the project's README file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,13 @@
 site_name: o2r web API
 pages:
-  - Index:      index.md
-  - Upload:     upload.md
-  - Job:        job.md
-  - Compendium: compendium.md
-  - Files:      files.md
-  - User:       user.md
-  - Search:     search.md
+  - Index:        index.md
+  - Upload:       upload.md
+  - Public share: public-share.md
+  - Job:          job.md
+  - Compendium:   compendium.md
+  - Files:        files.md
+  - User:         user.md
+  - Search:       search.md
 theme: readthedocs # flatly, cinder
 site_dir: docs/html
 extra_css: [o2r.css]


### PR DESCRIPTION
@nuest Hier der pull request für die API Spezifikation. Habe mich an der "upload" Dokumentation orientiert und ein paar Teile auch übernommen. Wenn etwas noch unklar, falsch, oder zu knapp ist, sag kurz Bescheid.

Testen konnte ich es mit *mkdocs* noch nicht; beim ausführen von `mkdocs serve` kommt (auf Windows) immer ein Fehler:

ERROR   -  Config value: 'site_dir'. Error: The 'site_dir' should not be within the 'docs_dir' as this leads to the build directory being copied into itself and duplicate nested files in the 'site_dir'

