### PR TITLE
suggestions for API extension to accommodate erc-checker

### DIFF
--- a/docs/job.md
+++ b/docs/job.md
@@ -80,12 +80,6 @@ Create and run a new execution job. Requires a `compendium_id`.
 {"error":"could not create job"}
 ```
 
-```json
-500 Internal Server Error
-
-{"error":"image contents invalid"}
-```
-
 ## List jobs
 
 Lists jobs. Will return up to 100 results by default.
@@ -147,7 +141,7 @@ The overall job state can be added to the job list response:
 - `limit` - Limits the number of results in the response. Defaults to 100.
 - `status` - Specify status to filter by. Can contain following `status`: `success`, `failure`, `running`.
 - `user` - Public user identifier to filter by.
-- `fields` - Specify if/which additional attributes results should contain. Can contain following `fields`: `status, check`. Defaults to none.
+- `fields` - Specify if/which additional attributes results should contain. Can contain following `fields`: `status`. Defaults to none.
 
 ## View single job
 
@@ -158,35 +152,80 @@ View details for a single job. The file listing format is described in [compendi
 `GET /api/v1/job/:id`
 
 ```json
-200 OK
+//200 OK
 
 {
-  "id":"nkm4L",
-  "compendium_id":"a4Dnm",
-  "creation_date": Date,
+  "id": "nkm4L",
+  "compendium_id": "a4Dnm",
+  "user": "0000-0001-9757-xxxx",
   "status": "failure",
-  "steps":{
-    "unpack":{
-      "status":"failure",
-      "start": Date,
-      "end": Date,
-      "text":"not a valid archive"
+  "steps": {
+    "validate-bag": {
+      "status":"skipped",
+      "text": "bag validation during job execution is disabled"
     },
-    …
-  },
-  "check": {
-    ...     // see erc-checker documentation @ https://github.com/o2r-project/erc-checker
-  }
-  "files":{
-    {FileListing}
-  }
+    "validate_compendium": {
+      "text": "compendium is invalid, but execution may continue",
+      "status": "failure",
+      "start": "2017-10-23T08:44:30.768Z",
+      "end": "2017-10-23T08:44:30.785Z"
+    },
+    "image_prepare": {
+     "text": "payload with 12800 total bytes",
+     "status": "success",
+     "start": "2017-10-23T08:44:30.789Z",
+     "end": "2017-10-23T08:44:31.013Z"
+    },
+    "image_build": {
+      "text": "Step 1/6 : FROM alpine\nStep 3/6 : ENV HOST 127.0.0.1\nSuccessfully tagged erc:nkm4L\n",
+      "status": "success",
+      "start": "2017-10-23T08:44:31.043Z",
+      "end": "2017-10-23T08:44:31.405Z"
+    },
+    "image_execute": {
+      "text": "PING 127.0.0.1 (127.0.0.1): 56 data bytes\r\n64 bytes from 127.0.0.1: seq=0 ttl=64 [TRUNCATED FOR EXAMPLE]",
+       "status": "success",
+      "start": "2017-10-23T08:44:31.561Z",
+      "end": "2017-10-23T08:45:01.160Z",
+      "statuscode": 0
+    },
+    "check": {
+        "status": "success",
+        "images": [
+            {
+                "imageIndex": 0,
+                "resizeOperationCode": 0,
+                "compareResults": {
+                    "differences": 0,
+                    "dimension": 1290240
+                }
+            }
+        ],
+        "resultHTML": "[merged HTML with difference highlighting for images]",
+        "timeOfCheck":
+        {
+            "start": "2017-10-23T08:45:01.168Z",
+            "end": "2017-10-23T08:45:02.193Z"
+        },
+        "errorsEncountered": []
+    },
+    "cleanup": {
+      "text": "Done: removed container.\nDone: kept image with tag erc:nkm4L for job nkm4L\nDone: deleted tmp payload file.",
+      "status": "success",
+      "start": "2017-10-23T08:45:01.201Z",
+      "end": "2017-10-23T08:45:01.226Z"
+    }
+  },  
+  "createdAt": "2017-10-23T08:44:30.693Z",
+  "updatedAt": "2017-10-23T08:45:01.237Z"
 }
 ```
 
 ### URL parameters for single job view
 
 - `:id` - id of the job to be viewed
-
+- `details` - Details of steps to be loaded. By default, only `status`, `start` and `end` of any step will be loaded. 
+Can contain the following `details`: `all, validate-bag, validate_compendium, image_prepare, image_build, image_execute, `
 ### Steps
 
 The answer will contain information regaring the job steps.

--- a/docs/job.md
+++ b/docs/job.md
@@ -157,7 +157,7 @@ View details for a single job. The file listing format is described in [compendi
 {
   "id": "nkm4L",
   "compendium_id": "a4Dnm",
-  "user": "0000-0001-9757-xxxx",
+  "user": "0000-0001-6021-1617",
   "status": "failure",
   "steps": {
     "validate-bag": {
@@ -201,7 +201,7 @@ View details for a single job. The file listing format is described in [compendi
           }
         }
       ],
-      "resultHTML": "[merged HTML with difference highlighting for images]",
+      "diffHTML": "[merged HTML with difference highlighting for images]",
       "start": "2017-10-23T08:45:01.168Z",
       "end": "2017-10-23T08:45:02.193Z",
       "errorsEncountered": []
@@ -221,8 +221,12 @@ View details for a single job. The file listing format is described in [compendi
 ### URL parameters for single job view
 
 - `:id` - id of the job to be viewed
-- `details` - Details of steps to be loaded. By default, only `status`, `start` and `end` of any step will be loaded. 
-Can contain the following `details`: `all, validate-bag, validate_compendium, image_prepare, image_build, image_execute, `
+- `details` - Details of steps to be loaded.  
+
+By default, only `status`, `start` and `end` of any step will be loaded.
+
+`details` may either be `all`, or a comma separated list of one or more step identifiers. Any other step values for `details` than the listed ones will return the default (e.g. `details=no`).
+
 ### Steps
 
 The answer will contain information regaring the job steps.

--- a/docs/job.md
+++ b/docs/job.md
@@ -201,10 +201,12 @@ View details for a single job. The file listing format is described in [compendi
           }
         }
       ],
-      "diffHTML": "[merged HTML with difference highlighting for images]",
+      "display": {
+        "diff": "[merged HTML with difference highlighting for images]"
+      },
       "start": "2017-10-23T08:45:01.168Z",
       "end": "2017-10-23T08:45:02.193Z",
-      "errorsEncountered": []
+      "errors": []
     },
     "cleanup": {
       "text": "Done: removed container.\nDone: kept image with tag erc:nkm4L for job nkm4L\nDone: deleted tmp payload file.",

--- a/docs/job.md
+++ b/docs/job.md
@@ -152,7 +152,7 @@ View details for a single job. The file listing format is described in [compendi
 `GET /api/v1/job/:id`
 
 ```json
-//200 OK
+200 OK
 
 {
   "id": "nkm4L",
@@ -184,30 +184,27 @@ View details for a single job. The file listing format is described in [compendi
     },
     "image_execute": {
       "text": "PING 127.0.0.1 (127.0.0.1): 56 data bytes\r\n64 bytes from 127.0.0.1: seq=0 ttl=64 [TRUNCATED FOR EXAMPLE]",
-       "status": "success",
+      "status": "success",
       "start": "2017-10-23T08:44:31.561Z",
       "end": "2017-10-23T08:45:01.160Z",
       "statuscode": 0
     },
     "check": {
-        "status": "success",
-        "images": [
-            {
-                "imageIndex": 0,
-                "resizeOperationCode": 0,
-                "compareResults": {
-                    "differences": 0,
-                    "dimension": 1290240
-                }
-            }
-        ],
-        "resultHTML": "[merged HTML with difference highlighting for images]",
-        "timeOfCheck":
+      "status": "success",
+      "images": [
         {
-            "start": "2017-10-23T08:45:01.168Z",
-            "end": "2017-10-23T08:45:02.193Z"
-        },
-        "errorsEncountered": []
+          "imageIndex": 0,
+          "resizeOperationCode": 0,
+          "compareResults": {
+            "differences": 0,
+            "dimension": 1290240
+          }
+        }
+      ],
+      "resultHTML": "[merged HTML with difference highlighting for images]",
+      "start": "2017-10-23T08:45:01.168Z",
+      "end": "2017-10-23T08:45:02.193Z",
+      "errorsEncountered": []
     },
     "cleanup": {
       "text": "Done: removed container.\nDone: kept image with tag erc:nkm4L for job nkm4L\nDone: deleted tmp payload file.",

--- a/docs/job.md
+++ b/docs/job.md
@@ -32,6 +32,8 @@ One job consists of a series of steps. All of these steps can be in one of three
   Send the bag's payload as a tarballed archive to Docker to build an image, which is tagged `bagtainer:<jobid>`.
 - **image_execute**
   Run the container and return based on status code of program that ran inside the container.
+- **check**
+  Run a check on the contents of the container. Validate the results of the executed calculations.
 - **cleanup**
   Remove image or job files (depending on server-side settings).
 
@@ -76,6 +78,12 @@ Create and run a new execution job. Requires a `compendium_id`.
 500 Internal Server Error
 
 {"error":"could not create job"}
+```
+
+```json
+500 Internal Server Error
+
+{"error":"image contents invalid"}
 ```
 
 ## List jobs
@@ -139,7 +147,7 @@ The overall job state can be added to the job list response:
 - `limit` - Limits the number of results in the response. Defaults to 100.
 - `status` - Specify status to filter by. Can contain following `status`: `success`, `failure`, `running`.
 - `user` - Public user identifier to filter by.
-- `fields` - Specify if/which additional attributes results should contain. Can contain following `fields`: `status`. Defaults to none.
+- `fields` - Specify if/which additional attributes results should contain. Can contain following `fields`: `status, check`. Defaults to none.
 
 ## View single job
 
@@ -166,6 +174,9 @@ View details for a single job. The file listing format is described in [compendi
     },
     …
   },
+  "check": {
+    ...     // see erc-checker documentation @ https://github.com/o2r-project/erc-checker
+  }
   "files":{
     {FileListing}
   }

--- a/docs/job.md
+++ b/docs/job.md
@@ -147,9 +147,9 @@ The overall job state can be added to the job list response:
 
 View details for a single job. The file listing format is described in [compendium files](compendium/files.md)
 
-`curl https://…/api/v1/job/$ID`
+`curl https://…/api/v1/job/$ID?details=all`
 
-`GET /api/v1/job/:id`
+`GET /api/v1/job/:id?details=all`
 
 ```json
 200 OK


### PR DESCRIPTION
I extended the Job Doc, which now presents the new Step "check", as well as the Job JSON example, including an example for a Check Result JSON, formatted in a similar fashion as the already included Steps.

There is also a suggestion for a new URL parameter. By default, a GET request for a particular Job will only feature limited information about the different steps of the job. That is to avoid superfluous data traffic, since the merged diffHTML, which are included as Strings in each Checker result JSON, may be pretty large (`>5mb`). 

By using the new URL parameter `details`, a user (/developer) may decide what step they want to recieve detailed information on. I suggest the option `all` to get all the details on all the steps, or instead listing each step required.